### PR TITLE
Add initial React Native app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # techclick.in
-We providing content reletaed to network security , cyber security and network engineer
+We provide content related to network security, cyber security and network engineering.
 
-Interview questions and answers of cisco ise
-ASA interview questions and answers
-Zscaler interview questions and answers
-Fortigate interview questions and answers
-Checkpoint interview questions and answers
-Cberarkinterview questions and answers
+- Interview questions and answers for Cisco ISE
+- ASA interview questions and answers
+- Zscaler interview questions and answers
+- Fortigate interview questions and answers
+- Checkpoint interview questions and answers
+- CyberArk interview questions and answers
 
-Visit your website- https://techclick.in
+Visit our website: <https://techclick.in>
 
-download all ios of networking for eveng 
+Download all networking IOS images for Eve-NG.
+
+## Mobile App
+A minimal React Native application is available in the [`mobile-app`](mobile-app) directory. Follow the instructions in that folder to run the app on your device using Expo.

--- a/mobile-app/App.js
+++ b/mobile-app/App.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Welcome to TechClick mobile application!</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#fff'
+  },
+  text: {
+    fontSize: 18,
+    color: '#333'
+  }
+});

--- a/mobile-app/README.md
+++ b/mobile-app/README.md
@@ -1,0 +1,20 @@
+# TechClick Mobile App
+
+This directory contains a simple React Native application built with Expo.
+
+## Prerequisites
+- Node.js and npm installed
+- [Expo CLI](https://docs.expo.dev/workflow/expo-cli/) installed globally: `npm install -g expo-cli`
+
+## Running the App
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm start
+   ```
+3. Use the Expo Go app on your mobile device or an emulator to view the app.
+
+The app displays a welcome message for **TechClick**.

--- a/mobile-app/index.js
+++ b/mobile-app/index.js
@@ -1,0 +1,4 @@
+import { registerRootComponent } from 'expo';
+import App from './App';
+
+registerRootComponent(App);

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "techclick-mobile",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^48.0.0",
+    "react": "18.1.0",
+    "react-native": "0.70.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add basic React Native app in `mobile-app`
- document how to run the mobile app
- update main README with mobile app instructions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68417de947488326af0399ab9300d28c